### PR TITLE
This fixes an ErrorException I'm getting when using the Analyze Permi…

### DIFF
--- a/XF/Admin/Controller/Permission.php
+++ b/XF/Admin/Controller/Permission.php
@@ -23,7 +23,7 @@ class Permission extends XFCP_Permission
         }
 
         // Ensure there is an analysis array
-        if ($analysis = $view->getParam('analysis'))
+        if ($analysis = $view->getParam('analysis') && isset($analysis[C::ADDON_ID_SHORT]))
         {
             // Getting an array of values for different groups (+ user value for specific users)
             $intermediates = $analysis[C::ADDON_ID_SHORT]['changeFrequency']['intermediates'];


### PR DESCRIPTION
…ssions tool. Below you can find the full trace:

ErrorException: [E_WARNING] array_shift() expects parameter 1 to be array, null given in src/addons/CMTV/UsernameChange/XF/Admin/Controller/Permission.php at line 32
XF::handlePhpError()
array_shift() in src/addons/CMTV/UsernameChange/XF/Admin/Controller/Permission.php at line 32
CMTV\UsernameChange\XF\Admin\Controller\Permission->actionAnalyze() in src/XF/Mvc/Dispatcher.php at line 321
XF\Mvc\Dispatcher->dispatchClass() in src/XF/Mvc/Dispatcher.php at line 248
XF\Mvc\Dispatcher->dispatchFromMatch() in src/XF/Mvc/Dispatcher.php at line 100
XF\Mvc\Dispatcher->dispatchLoop() in src/XF/Mvc/Dispatcher.php at line 50
XF\Mvc\Dispatcher->run() in src/XF/App.php at line 2177
XF\App->run() in src/XF.php at line 390
XF::runApp() in admin.php at line 13